### PR TITLE
fix: order-service httpx dep + frontend icon COPY (unblock staging deploy)

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -33,9 +33,8 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 # Copy public folder from source (not builder) since standalone doesn't include it
 COPY public ./public
-# Copy app icons for Next.js 15 App Router (from source, not builder)
-COPY app/favicon.ico ./app/favicon.ico
-COPY app/icon.svg ./app/icon.svg
+# App Router icons: favicon.ico + icon.svg are served from public/ (copied above).
+# Only apple-icon.png lives under app/, so copy just that one.
 COPY app/apple-icon.png ./app/apple-icon.png
 
 # Cloud Run provides PORT automatically; listen on dynamic port

--- a/backend/order-service-fastapi/requirements.txt
+++ b/backend/order-service-fastapi/requirements.txt
@@ -9,3 +9,4 @@ structlog==24.4.0
 pydantic==2.10.0
 pydantic-settings==2.6.0
 python-jose[cryptography]==3.3.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
Fixes the two regressions from `2a1d31f` (services refactor) that broke the staging deploy on 2026-06-06. 7/8 services deployed fine; **order-service** and **frontend** failed.

## Root causes
1. **order-service** — `app/services/notification_client.py` does `import httpx`, but `requirements.txt` never listed it. The image built OK, the container crashed at startup with `ModuleNotFoundError: No module named 'httpx'`, so the Cloud Run revision never became ready (PORT 8080 timeout). **Fix:** add `httpx==0.27.0` (matches the pin used by the other FastAPI services).
2. **frontend** — `Dockerfile.frontend` COPY'd `app/favicon.ico` + `app/icon.svg`, which now live under `public/` (already copied via `COPY public ./public`). Cloud Build failed at the runner COPY step. **Fix:** drop the two stale COPY lines; keep `apple-icon.png` (exists in `app/`).

## Test Plan (local, real builds)
- [x] order-service image `docker build` OK → container boots: `Application startup complete` / uvicorn on `:8080` / `Up (healthy)`; no httpx error.
- [x] frontend image `docker build` OK → passes the previously-failing runner COPY stage.
- [ ] Staging deploy goes green after merge (final verification).

## Scope
- `backend/order-service-fastapi/requirements.txt` (+1 line)
- `Dockerfile.frontend` (-2 stale COPY lines)

## Notes
Separate from, and a prerequisite for, the upcoming CI/CD split + caching + sharding optimization work.
