### PR TITLE
fix(cd): _json_key Artifact Registry login (fix IAM_PERMISSION_DENIED on deploy)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -141,7 +141,6 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-          token_format: access_token
 
       - uses: google-github-actions/setup-gcloud@v2
 
@@ -149,8 +148,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -283,13 +282,12 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-          token_format: access_token
       - uses: google-github-actions/setup-gcloud@v2
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          username: _json_key
+          password: ${{ secrets.GCP_SA_KEY }}
       - uses: docker/setup-buildx-action@v3
       - name: Resolve backend URL
         id: be


### PR DESCRIPTION
First real build-deploy run failed at auth for every service: `token_format: access_token` needs `iam.serviceAccountTokenCreator` on orderly-cicd@ (denied). Fix without IAM change: drop token_format, log in to AR via docker/login-action with `username=_json_key` + raw SA key JSON. Canonical AR key-based login; static basic-auth buildx reads directly. actionlint clean.