### PR TITLE
chore(cd): 關閉 production 自動部署(prod 尚未建置)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,14 @@ name: CD
 
 on:
   push:
-    branches: [staging, main]
+    # PRODUCTION AUTO-DEPLOY DISABLED (2026-06-08): the prod DB (orderly-db Cloud
+    # SQL) is not provisioned, so every push to main hit the preflight gate's
+    # "orderly-db not found" → red with ZERO deploy. `main` is removed from the
+    # auto-deploy push triggers until production is actually set up. To deploy
+    # prod, run this workflow manually via workflow_dispatch (and only after
+    # orderly-db exists). Staging (push to `staging` branch → orderly-db-v2) is
+    # unaffected. Re-add `main` here when prod infra is ready.
+    branches: [staging]
   workflow_dispatch:
     inputs:
       services:


### PR DESCRIPTION
目前不設置 production。移除 cd.yml push 觸發的 `main`,讓 push 到 main 不再自動試 prod 部署、不再每次卡 preflight(無 orderly-db)變紅、零部署。

- prod 之後要部署:建好 orderly-db 後,手動 workflow_dispatch(或把 main 加回)。
- staging(push `staging` branch → orderly-db-v2)不受影響。
- 本機驗:actionlint + yaml OK。