### PR TITLE
chore(ci): 修活 pre-push hook(裝 husky)+ escape hatch 粒度化

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -20,10 +20,20 @@ if [ -n "$REFS_INPUT" ]; then
   fi
 fi
 
-# Detect SKIP_VERIFY_PUSH escape hatch
+# SKIP_VERIFY_PUSH escape hatch — does NOT skip everything. The frontend gate
+# (`make verify`: lint / typecheck / format-check / test-fe) runs WITHOUT a
+# backend venv or DB, so it MUST still run — skipping it is how a prettier
+# regression leaked to CI (2026-06-08, PR #8: .eslintrc-security.js unformatted).
+# The escape hatch only waives `make test-be` (needs a venv + Postgres that a
+# bare worktree may lack). Use `git push --no-verify` to bypass the hook entirely
+# (logged by git), but that is the loud, deliberate exit — not the default.
 if [ -n "$SKIP_VERIFY_PUSH" ]; then
-  echo "pre-push: SKIP_VERIFY_PUSH set, skipping verification"
-  exit 0
+  echo "pre-push: SKIP_VERIFY_PUSH set — still running frontend 'make verify' (only test-be waived)"
+  if make verify; then
+    exit 0
+  fi
+  echo "pre-push: frontend 'make verify' FAILED — SKIP_VERIFY_PUSH does not waive the frontend gate; fix before pushing"
+  exit 1
 fi
 
 # Resolve TARGET (default: verify-pr-local)

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.0",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.0",
@@ -9641,6 +9642,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "clean": "rm -rf .next",
     "setup": "npm install && npm run build",
-    "dev:backend": "docker-compose -f compose.monolith.yml up backend"
+    "dev:backend": "docker-compose -f compose.monolith.yml up backend",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -115,6 +116,7 @@
     "babel-jest": "^29.7.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.0",


### PR DESCRIPTION
RCA(local verify 反覆漏)真修:

1. `.husky/pre-push` 之前是**死碼**——husky 從沒裝、core.hooksPath unset、`.git/hooks/pre-push` 不存在,git 從不跑它。所以 pre-push verify gate 形同虛設(這 session 我 push 從沒觸發過 hook)。
2. 裝 husky(devDep + `prepare: husky` + core.hooksPath=.husky/_),hook 真 active。
3. escape hatch 粒度化:`SKIP_VERIFY_PUSH` 不再全跳,仍跑 `make verify`(前端 lint/typecheck/format-check/test-fe,無 venv 能跑),只豁免 `test-be`(需 venv/DB)。

**自驗:** 本次 push 觸發 hook,log 顯示 `SKIP_VERIFY_PUSH set — still running frontend make verify` + format-check 跑 + `✓ verify passed`。從死碼變真生效。prettier regression class(PR #8 漏到 CI 那個)現在本機就擋。