### PR TITLE
chore(ci): 補 security-scan 的 local mirror(local↔CI 完全對齊)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,39 +196,28 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: detect-changes
+    # Scan logic + blocking policy live in scripts/ci/security-scan.sh so CI and
+    # the local `make security-scan` (in verify-pr-local) run the SAME thing.
+    # Tool install stays env-specific (CI installs gitleaks/pip-audit below;
+    # locally they advisory-skip if absent).
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: gitleaks secret scan (advisory until history is swept once)
-        # Orderly's git history predates this gate and may contain old test
-        # secrets; run advisory now (surface findings) and flip to blocking
-        # (drop continue-on-error) after a one-pass sweep + .gitleaks.toml allowlist.
-        continue-on-error: true
+      - name: Install gitleaks
         run: |
           GITLEAKS_VERSION="8.21.2"
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
-          gitleaks detect --source=. --redact --verbose --exit-code 1
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: npm audit — production deps, BLOCK on critical
-        # --omit=dev: dev-only vulns (eslint / @typescript-eslint toolchain) never
-        # ship to the running service. Block on critical (currently 0). The 3
-        # low-exploitability prod highs (next DoS / glob / minimatch) are surfaced
-        # in the advisory step below until the `next` major bump clears them.
-        run: npm audit --omit=dev --audit-level=critical
-      - name: npm audit high (advisory surface)
-        continue-on-error: true
-        run: npm audit --omit=dev --audit-level=high
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: pip-audit backend deps (advisory surface)
-        continue-on-error: true
-        run: |
-          pip install pip-audit
-          pip-audit -r backend/app/requirements.txt
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Security scan (shared runner — same script as `make security-scan`)
+        run: bash scripts/ci/security-scan.sh
 
   ci-gate:
     name: CI Gate

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
        test-be test-fe \
        lint typecheck format-check \
        verify verify-pr-local verify-pr \
-       deploy-check predeploy-check
+       deploy-check predeploy-check security-scan
 
 # Parallelism control
 PYTEST_WORKERS ?= auto
@@ -127,8 +127,14 @@ verify: lint typecheck format-check test-fe
 # test-be now runs the same monolith gate CI does (scripts/ci/backend-test.sh),
 # so a backend failure blocks the push instead of surfacing later in Actions.
 
-verify-pr-local: verify test-be deploy-check
-	@echo "✓ verify-pr-local passed (verify + monolith backend test + deploy-check, mirrors CI/CD)"
+# Mirror of ci.yml `security-scan` job — same scripts/ci/security-scan.sh
+# (gitleaks + npm audit --omit=dev + pip-audit). Runs locally so a security
+# finding surfaces before push, not CI-only.
+security-scan:
+	bash scripts/ci/security-scan.sh
+
+verify-pr-local: verify test-be deploy-check security-scan
+	@echo "✓ verify-pr-local passed (verify + backend test + deploy-check + security-scan, mirrors CI)"
 
 # ── PR CI gate: authoritative ──
 # CI .github/workflows/ci.yml is the source of truth for backend test results.

--- a/scripts/ci/security-scan.sh
+++ b/scripts/ci/security-scan.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Single source of truth for the security scan. Called by BOTH the ci.yml
+# security-scan job AND `make security-scan` (wired into verify-pr-local), so the
+# scan runs locally before push instead of CI-only — same reasoning as
+# scripts/ci/backend-test.sh. Tool installation stays env-specific (CI installs
+# gitleaks/pip-audit; locally they advisory-skip if absent); the SCAN logic +
+# blocking policy live here so CI and local can't drift.
+#
+# Policy:
+#   - npm audit (production deps) BLOCKS on critical. The 3 low-exploitability
+#     prod highs (next DoS / glob / minimatch) are surfaced, not blocking, until
+#     the next major bump.
+#   - gitleaks (secret scan) + pip-audit are ADVISORY (surface, never block) until
+#     git history is swept once / backend findings are triaged.
+set -uo pipefail   # deliberately NOT -e: per-check exit is controlled below
+fail=0
+
+echo "==> gitleaks (secret scan, advisory)"
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks detect --source=. --redact --verbose --exit-code 1 \
+    || echo "::warning::gitleaks: potential secrets found (advisory until history is swept)"
+else
+  echo "::warning::gitleaks not on PATH — skipped (CI installs + runs it; install locally to mirror)"
+fi
+
+echo "==> npm audit --omit=dev --audit-level=critical (BLOCKING)"
+if command -v npm >/dev/null 2>&1; then
+  npm audit --omit=dev --audit-level=critical \
+    || { echo "::error::npm audit: production CRITICAL vulnerability — blocking"; fail=1; }
+else
+  echo "::error::npm not found — cannot run npm audit"; fail=1
+fi
+
+echo "==> npm audit --omit=dev --audit-level=high (advisory surface)"
+if command -v npm >/dev/null 2>&1; then
+  npm audit --omit=dev --audit-level=high \
+    || echo "::warning::npm audit: production HIGH vulns (advisory until next major bump: next/glob/minimatch)"
+fi
+
+echo "==> pip-audit backend deps (advisory surface)"
+if [ -f backend/app/requirements.txt ]; then
+  if command -v pip-audit >/dev/null 2>&1; then
+    pip-audit -r backend/app/requirements.txt \
+      || echo "::warning::pip-audit: backend findings (advisory)"
+  else
+    echo "::warning::pip-audit not installed — skipped (CI installs it; pip install pip-audit to mirror)"
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "❌ security-scan FAILED (blocking finding above)"
+  exit 1
+fi
+echo "✓ security-scan passed (blocking checks clean; advisory findings surfaced above)"


### PR DESCRIPTION
補上最後一個 local↔CI gap。PR #8 加了 ci.yml security-scan job 卻沒 local 對應 → 安全掃描 CI-only(正是本 session 開頭 RCA 要殺的 divergence,我自己又引入)。

抽 `scripts/ci/security-scan.sh` 共用(ci.yml job + 新 `make security-scan` 都呼叫),security-scan 進 verify-pr-local。npm audit critical 擋;gitleaks/pip-audit/high advisory。

**local↔CI 對齊後:**
- frontend → make verify (lint/typecheck/format-check/jest --ci)
- backend → make test-be (backend-test.sh 共用)
- deploy → make deploy-check
- security → make security-scan (security-scan.sh 共用) ← 本次補

本機驗:script syntax + actionlint + yaml 清;make security-scan exit 0。